### PR TITLE
Add onnx export

### DIFF
--- a/src/inpainting_metrics.py
+++ b/src/inpainting_metrics.py
@@ -6,7 +6,8 @@ import numpy as np
 import torch
 from scipy import linalg
 from skimage.color import rgb2gray
-from skimage.measure import compare_ssim
+from skimage.metrics import structural_similarity
+#from skimage.measure import compare_ssim
 from torch.autograd import Variable
 from torch.nn.functional import adaptive_avg_pool2d
 from tqdm import tqdm
@@ -227,7 +228,7 @@ def get_inpainting_metrics(src, tgt, logger, fid_test=True):
         mse_ = np.mean((img1 / 255.0 - img2 / 255.0) ** 2)
         mae_ = np.mean(abs(img1 / 255.0 - img2 / 255.0))
         psnr_ = max_value - 10 * np.log(mse_ + 1e-7) / np.log(10)
-        ssim_ = compare_ssim(rgb2gray(img1), rgb2gray(img2))
+        ssim_ = structural_similarity(rgb2gray(img1), rgb2gray(img2))
         psnrs.append(psnr_)
         ssims.append(ssim_)
         mses.append(mse_)


### PR DESCRIPTION
This fixes #71 

I used this command with `InpaintingModel_best_gen.pth` weight and [config_ZITS_places2.yml](https://github.com/DQiaole/ZITS_inpainting/blob/main/config_list/config_ZITS_places2.yml) file

```bash
python single_image_test.py --checkpoints ./checkpoints/ --config_file config_list/config_ZITS_places2.yml --onnx --save_path ./
```

and placed these weights `StructureUpsampling.pth` and `best_transformer_places2.pth` inside `ckpt` folder


There are some errors in `ONNX` export function though, can you help me to understand these errors?

```
BaseInpaintingTrainingModule init called
Loading InpaintingModel StructureUpsampling...
Loading trained transformer...
Loading InpaintingModel generator...
Warnning: There is no previous optimizer found. An initialized optimizer will be used.
Warnning: There is no previous optimizer found. An initialized optimizer will be used.
Traceback (most recent call last):
  File "/home/ZITS_inpainting/single_image_test.py", line 356, in <module>
    export_onnx(model, args.save_path)
  File "/home/ZITS_inpainting/single_image_test.py", line 297, in export_onnx
    torch.onnx.export(model,         # model being run
  File "/home/.local/lib/python3.10/site-packages/torch/onnx/utils.py", line 506, in export
    _export(
  File "/home/.local/lib/python3.10/site-packages/torch/onnx/utils.py", line 1525, in _export
    with exporter_context(model, training, verbose):
  File "/usr/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/home/.local/lib/python3.10/site-packages/torch/onnx/utils.py", line 178, in exporter_context
    with select_model_mode_for_export(
  File "/usr/lib/python3.10/contextlib.py", line 135, in __enter__
    return next(self.gen)
  File "/home/.local/lib/python3.10/site-packages/torch/onnx/utils.py", line 139, in disable_apex_o2_state_d
ict_hook
    for module in model.modules():
AttributeError: 'ZITS' object has no attribute 'modules'
```